### PR TITLE
Add unanimous pick rule to draw logic and entry rename command

### DIFF
--- a/database/controllers/entry_hist.py
+++ b/database/controllers/entry_hist.py
@@ -77,6 +77,17 @@ async def read_all_entry_hist_for_user_in_guild(guild_id: int, user_id: int) -> 
             logger.error(e)
             return None
 
+async def update_all_entry_hist_in_guild_by_name(guild_id: int, old_name: str, new_name: str) -> bool:
+    async with aiosqlite.connect(DATABASE_PATH) as db:
+        try:
+            await db.execute("UPDATE entry_hist SET name=? WHERE guild_id=? AND name=?",
+                             (new_name, guild_id, old_name,))
+            await db.commit()
+            return True
+        except Exception as e:
+            logger.error(e)
+            return False
+
 async def delete_all_entry_hist() -> bool:
     async with aiosqlite.connect(DATABASE_PATH) as db:
         try:


### PR DESCRIPTION
- Add logic to draw function such that if all users selected a common choice then that choice wins automatically (no random draw needed)
- Added rename draw entry command to modify the history table for picks that are the same but spelled differently (ex. "lol" vs "league")
- Added the ability to specify how many draws to run when manually running the "draw_now" command